### PR TITLE
Import Iterable from collections.abc for Python 3.10+ support

### DIFF
--- a/drf_serpy/serializer.py
+++ b/drf_serpy/serializer.py
@@ -1,5 +1,5 @@
 import operator
-from collections import Iterable
+from collections.abc import Iterable
 from typing import Any, Dict, List, Tuple, Type, Union
 
 from drf_yasg import openapi


### PR DESCRIPTION
Import Iterable from collections.abc for Python 3.10+ support