### PR TITLE
Hugely optimization for the DRF serpy serializer by not using the iterator()

### DIFF
--- a/drf_serpy/serializer.py
+++ b/drf_serpy/serializer.py
@@ -2,9 +2,8 @@ import operator
 from collections.abc import Iterable
 from typing import Any, Dict, List, Tuple, Type, Union
 
-from drf_yasg import openapi
-
 from drf_serpy.fields import Field, MethodField
+from drf_yasg import openapi
 
 SCHEMA_MAPPER = {
     str: openapi.TYPE_STRING,
@@ -148,9 +147,6 @@ class Serializer(SerializerBase, metaclass=SerializerMeta):
 
         if self.many:
             serialize = self._serialize
-            # django orm support for m2m fields
-            if getattr(instance, "iterator", None):
-                return [serialize(o, fields) for o in instance.iterator()]
             return [serialize(o, fields) for o in instance]
         return self._serialize(instance, fields)
 


### PR DESCRIPTION
Which, AFAIK, is not needed and degrading performance with ORM queryset. Unfortunately, the benchmarks are using basic Python types, so it's not surfacing the current slowness of DRF-Serpy compared with DRF.

Benchmark before and after the change:

![2023-10-02_16-36](https://github.com/sergenp/drf-serpy/assets/136875/b17f8eda-e430-43ef-aa9e-850fb482f70e)
